### PR TITLE
Add Github CI with `cargo-checkmate`.

### DIFF
--- a/.github/workflows/cargo-checkmate.yaml
+++ b/.github/workflows/cargo-checkmate.yaml
@@ -1,0 +1,17 @@
+on: [push, pull_request]
+
+name: cargo-checkmate Continuous Integration
+
+jobs:
+  cargo-checkmate:
+    name: cargo-checkmate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - run: cargo install cargo-checkmate
+      - run: cargo-checkmate


### PR DESCRIPTION
This adds Github Action CI that uses [cargo-checkmate](https://github.com/cargo-checkmate/cargo-checkmate) which verifies that a bunch of standard cargo targets like `check`, `test`, and `doc` succeed. It also runs `cargo-audit` (from [rustsec](https://github.com/rustsec/rustsec)) to check for announced security vulnerabilities in any dependencies.